### PR TITLE
updater.sh: avoid iomem=relaxed to be set permanently

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -553,7 +553,7 @@ print_iomem_relaxed_instructions()
 		;;
 	*" fedora "*)
 		printf "Fedora: run:\n" >&2
-		printf "  sudo grubby --update-kernel=ALL --args=\"iomem=relaxed\"\n" >&2
+		printf "  sudo grubby --update-kernel=ALL --no-etc-grub-update --args=\"iomem=relaxed\"\n" >&2
 		printf "  reboot\n" >&2
 		;;
 	*" arch "*|*" endeavouros "*|*" manjaro "*)


### PR DESCRIPTION
This script seems to permanently change the grub config defaults of Fedora, and therefore will disable a security-relevant function also in future kernel updates. This should be avoided.

As far as I know, a recent firmware update of StarLabs has fixed the need for `iomem=relaxed`, so that this is only necessary for users who have to update from a very old firmware: therefore, it should be fine to just update the current grub config files for `iomem=relaxed` and leave the default for future kernel updates the way it was before.

I did only implement a quick and "as simple as possible" fix in order to illustrate the issue comprehensibly, but this fix might also serve as interim-solution to avoid that the script impacts the defaults for future updates on Fedora. 

I did only consider Fedora, other OS might be affected too. I have limited possibilities to test this.

Thanks for providing these great devices and for taking care that they offer a smooth use of Linux distributions :) 