### PR TITLE
updater.sh: bump coreboot to 26.06, fix ssh usage

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+# If stdout is a terminal but its terminfo is missing on this host (common
+# over SSH with an exotic client TERM such as xterm-ghostty/xterm-kitty),
+# fall back to a near-universal entry so the tput calls below don't abort
+# the whole script under `set -e`.
+if [[ -t 1 ]] && ! tput sgr0 >/dev/null 2>&1; then
+	export TERM=xterm-256color
+fi
+
 if [[ -t 1 ]]; then
 	RED="$(tput setaf 1)"
 	GREEN="$(tput setaf 2)"

--- a/updater.sh
+++ b/updater.sh
@@ -37,7 +37,7 @@ else
 	SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)"
 fi
 
-COREBOOT_TARGET_VERSION="26.05"
+COREBOOT_TARGET_VERSION="26.06"
 
 firmware_raw_branch()
 {

--- a/updater.sh
+++ b/updater.sh
@@ -2,10 +2,8 @@
 
 set -euo pipefail
 
-# If stdout is a terminal but its terminfo is missing on this host (common
-# over SSH with an exotic client TERM such as xterm-ghostty/xterm-kitty),
-# fall back to a near-universal entry so the tput calls below don't abort
-# the whole script under `set -e`.
+# If stdout is a terminal but its terminfo is missing on this host
+# tput calls abort the whole script under `set -e`. This avoids that
 if [[ -t 1 ]] && ! tput sgr0 >/dev/null 2>&1; then
 	export TERM=xterm-256color
 fi


### PR DESCRIPTION
Sets coreboot target to 26.06

Fixes the updater.sh when run via ssh
